### PR TITLE
feat: add initial barebones recipe list with two recipies that just have names

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,3 +30,7 @@
   font-size: 1.2rem;
   color: #666;
 }
+
+.App-header ul {
+  text-align: left;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,6 @@
   color: #666;
 }
 
-.App-header ul {
+.App-header div {
   text-align: left;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './App.css';
-import RecipeList from './components/RecipeList/RecipeList';
+import RecipeList from './components/RecipeList';
 
 const App: React.FC = () => {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import './App.css';
+import RecipeList from './components/RecipeList/RecipeList';
 
 const App: React.FC = () => {
   return (
     <div className="App">
       <header className="App-header">
-        <h1>Hello World! 👋</h1>
-        <p>This is a simple React app deployed to GitHub Pages</p>
+        <h1>Recipes</h1>
+        <RecipeList />
       </header>
     </div>
   );

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Recipe } from '../../types/Recipe';
 import { allRecipes } from '../../data/allRecipes';
 
 /**

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Recipe } from '../../types/Recipe';
+import { allRecipes } from '../../data/allRecipes';
+
+/**
+ * Component that displays a list of all available recipes, without caring about specific details (e.g. steps) about it.
+ */
+const RecipeList: React.FC = () => {
+  const recipes: Recipe[] = allRecipes;
+
+  return (
+    <div>
+      {recipes.map((recipe) => (
+        <div key={recipe.id}>{recipe.name}</div>
+      ))}
+    </div>
+  );
+};
+
+export default RecipeList;

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -6,11 +6,11 @@ import { allRecipes } from '../../data/allRecipes';
  * Component that displays a list of all available recipes, without caring about specific details (e.g. steps) about it.
  */
 const RecipeList: React.FC = () => {
-  const recipes: Recipe[] = allRecipes;
+
 
   return (
     <div>
-      {recipes.map((recipe) => (
+      {allRecipes.map((recipe) => (
         <div key={recipe.id}>{recipe.name}</div>
       ))}
     </div>

--- a/src/components/RecipeList/index.ts
+++ b/src/components/RecipeList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RecipeList';

--- a/src/data/allRecipes.ts
+++ b/src/data/allRecipes.ts
@@ -1,0 +1,13 @@
+import { Recipe } from '../types/Recipe';
+import { spaghettiCarbonara } from './recipes/spaghettiCarbonara';
+import { chickenTikkaMasala } from './recipes/chickenTikkaMasala';
+
+/**
+ * Complete list of recipes.
+ * 
+ * When adding a new recipe, remember to add it here!
+ */
+export const allRecipes: Recipe[] = [
+  { id: 1, ...spaghettiCarbonara },
+  { id: 2, ...chickenTikkaMasala }
+];

--- a/src/data/allRecipes.ts
+++ b/src/data/allRecipes.ts
@@ -4,7 +4,7 @@ import { chickenTikkaMasala } from './recipes/chickenTikkaMasala';
 
 /**
  * Complete list of recipes.
- * 
+ *
  * When adding a new recipe, remember to add it here!
  */
 export const allRecipes: Recipe[] = [

--- a/src/data/recipes/chickenTikkaMasala.ts
+++ b/src/data/recipes/chickenTikkaMasala.ts
@@ -1,0 +1,5 @@
+import { BaseRecipe } from '../../types/Recipe';
+
+export const chickenTikkaMasala: BaseRecipe = {
+  name: "Chicken Tikka Masala"
+};

--- a/src/data/recipes/spaghettiCarbonara.ts
+++ b/src/data/recipes/spaghettiCarbonara.ts
@@ -1,0 +1,5 @@
+import { BaseRecipe } from '../../types/Recipe';
+
+export const spaghettiCarbonara: BaseRecipe = {
+  name: "Spaghetti Carbonara"
+};

--- a/src/types/Recipe.ts
+++ b/src/types/Recipe.ts
@@ -1,0 +1,15 @@
+/**
+ * Base recipe information - represents the core recipe details
+ */
+export interface BaseRecipe {
+  /** The display name of the recipe */
+  name: string;
+}
+
+/**
+ * Complete recipe with unique identifier - used for the final recipe list
+ */
+export interface Recipe extends BaseRecipe {
+  /** Unique identifier */
+  id: number;
+}


### PR DESCRIPTION
Replaces the boring splash screen with a list of two recipes. 

To do this, introduced two recipe types: `BaseRecipe` which is intended to be the core recipe (e.g. ingredients, steps, and so on..) and `Recipe`, which is a wrapper around the `BaseRecipe` with an id for react.

Currently recipies are defined as typescript files. I am not yet convinced this is a good idea :)

<img width="1680" height="962" alt="image" src="https://github.com/user-attachments/assets/87663732-7ca5-4b2c-a2e6-c223a483725a" />
