### PR TITLE
Fix GitHub Pages routing with HashRouter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import './App.css';
 import RecipeList from './components/RecipeList/RecipeList';
 import RecipeDetail from './components/RecipeDetail/RecipeDetail';


### PR DESCRIPTION
Use HashRouter instead of BrowserRouter to avoid routing issues on GitHub Pages. URLs will now use hash-based routing (e.g., /#/recipe/1) which works perfectly with static hosting.