### PR TITLE
refactor: Simplified Recipe model to just be a single class instead of using abstraction when not necessary

### DIFF
--- a/src/components/RecipeDetail/RecipeDetail.tsx
+++ b/src/components/RecipeDetail/RecipeDetail.tsx
@@ -7,8 +7,10 @@ import { allRecipes } from '../../data/allRecipes';
  * Uses URL parameter to find and display the specific recipe
  */
 const RecipeDetail: React.FC = () => {
+  // Fetch id from uri query params.
   const { id } = useParams<{ id: string }>();
-  const recipe = allRecipes.find(r => r.id === Number(id));
+
+  const recipe = allRecipes.find(recipe => recipe.id === id);
 
   if (!recipe) {
     return (

--- a/src/data/allRecipes.ts
+++ b/src/data/allRecipes.ts
@@ -3,11 +3,11 @@ import { spaghettiCarbonara } from './recipes/spaghettiCarbonara';
 import { chickenTikkaMasala } from './recipes/chickenTikkaMasala';
 
 /**
- * Complete list of recipes.
+ * Complete list of all recipes.
  *
  * When adding a new recipe, remember to add it here!
  */
 export const allRecipes: Recipe[] = [
-  { id: 1, ...spaghettiCarbonara },
-  { id: 2, ...chickenTikkaMasala }
+  spaghettiCarbonara,
+  chickenTikkaMasala
 ];

--- a/src/data/recipes/chickenTikkaMasala.ts
+++ b/src/data/recipes/chickenTikkaMasala.ts
@@ -1,5 +1,6 @@
-import { BaseRecipe } from '../../types/Recipe';
+import { Recipe } from '../../types/Recipe';
 
-export const chickenTikkaMasala: BaseRecipe = {
+export const chickenTikkaMasala: Recipe = {
+  id: "chicken-tikka-masala",
   name: "Chicken Tikka Masala"
 };

--- a/src/data/recipes/spaghettiCarbonara.ts
+++ b/src/data/recipes/spaghettiCarbonara.ts
@@ -1,5 +1,6 @@
-import { BaseRecipe } from '../../types/Recipe';
+import { Recipe } from '../../types/Recipe';
 
-export const spaghettiCarbonara: BaseRecipe = {
+export const spaghettiCarbonara: Recipe = {
+  id: "spaghetti-carbonara",
   name: "Spaghetti Carbonara"
 };

--- a/src/types/Recipe.ts
+++ b/src/types/Recipe.ts
@@ -1,15 +1,7 @@
 /**
- * Base recipe information - represents the core recipe details
+ * A single recipe, with everything included.
  */
-export interface BaseRecipe {
-  /** The display name of the recipe */
-  name: string;
-}
-
-/**
- * Complete recipe with unique identifier - used for the final recipe list
- */
-export interface Recipe extends BaseRecipe {
-  /** Unique identifier */
-  id: number;
+export interface Recipe {
+  id: string;
+  name: string
 }


### PR DESCRIPTION
Remove BaseRecipe and removed the extra Recipe layer ontop of it - so now there is just a single Recipe class. Then I can add the other one again when/if I never need it.. 