### PR TITLE
feat: Add recipe categories

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ const App: React.FC = () => {
           <h1>Recipes</h1>
           <Routes>
             <Route path="/" element={<RecipeList />} />
-            <Route path="/recipe/:id" element={<RecipeDetail />} />
+            <Route path="/category/:category" element={<RecipeList />} />
+            <Route path="/category/:category/recipe/:id" element={<RecipeDetail />} />
           </Routes>
         </header>
       </div>

--- a/src/components/Category/Category.css
+++ b/src/components/Category/Category.css
@@ -1,0 +1,12 @@
+.category {
+  display: inline-block;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border: 1px solid #666;
+  background-color: #f5f5f5;
+  color: #666;
+}

--- a/src/components/Category/Category.tsx
+++ b/src/components/Category/Category.tsx
@@ -3,16 +3,16 @@ import './Category.css';
 
 interface CategoryProps {
   /** The category name to display */
-  category: string;
+  name: string;
 }
 
 /**
  * Component for displaying recipe category with consistent styling
  */
-const Category: React.FC<CategoryProps> = ({ category }) => {
+const Category: React.FC<CategoryProps> = ({ name }) => {
   return (
     <span className="category">
-      {category}
+      {name}
     </span>
   );
 };

--- a/src/components/Category/Category.tsx
+++ b/src/components/Category/Category.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import './Category.css';
+
+interface CategoryProps {
+  /** The category name to display */
+  category: string;
+}
+
+/**
+ * Component for displaying recipe category with consistent styling
+ */
+const Category: React.FC<CategoryProps> = ({ category }) => {
+  return (
+    <span className="category">
+      {category}
+    </span>
+  );
+};
+
+export default Category;

--- a/src/components/Category/index.ts
+++ b/src/components/Category/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Category';

--- a/src/components/RecipeDetail/RecipeDetail.tsx
+++ b/src/components/RecipeDetail/RecipeDetail.tsx
@@ -9,8 +9,8 @@ import './RecipeDetail.css';
  * Uses URL parameter to find and display the specific recipe
  */
 const RecipeDetail: React.FC = () => {
-  // Fetch id and category from uri query params.
-  const { id, category } = useParams<{ id: string; category?: string }>();
+  // Fetch id from uri query params.
+  const { id } = useParams<{ id: string }>();
 
   const recipe = allRecipes.find(recipe => recipe.id === id);
 

--- a/src/components/RecipeDetail/RecipeDetail.tsx
+++ b/src/components/RecipeDetail/RecipeDetail.tsx
@@ -9,8 +9,8 @@ import './RecipeDetail.css';
  * Uses URL parameter to find and display the specific recipe
  */
 const RecipeDetail: React.FC = () => {
-  // Fetch id from uri query params.
-  const { id } = useParams<{ id: string }>();
+  // Fetch id and category from uri query params.
+  const { id, category } = useParams<{ id: string; category?: string }>();
 
   const recipe = allRecipes.find(recipe => recipe.id === id);
 
@@ -25,7 +25,10 @@ const RecipeDetail: React.FC = () => {
 
   return (
     <div className="recipe-detail">
-      <Breadcrumb currentPageLabel={recipe.name} />
+      <Breadcrumb 
+        currentPageLabel={recipe.name} 
+        additionalBreadcrumbItems={[{ label: recipe.category, path: `/category/${recipe.category}` }]}
+      />
       <h1 className="recipe-title">{recipe.name}</h1>
       
       <section className="ingredients-section">

--- a/src/components/RecipeList/RecipeList.css
+++ b/src/components/RecipeList/RecipeList.css
@@ -1,7 +1,51 @@
+.recipe-list-container {
+  margin-top: 2rem;
+}
+
+.categories-section {
+  margin-bottom: 2rem;
+}
+
+.categories-section h2 {
+  font-size: 1rem;
+  font-weight: 500;
+  color: #666;
+  margin: 0 0 0.75rem 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.categories-list {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.category-filter {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.category-filter:hover {
+  opacity: 0.7;
+}
+
+.category-filter.active {
+  opacity: 1;
+}
+
+.category-filter:not(.active) {
+  opacity: 0.4;
+}
+
+
+
 .recipe-list {
   display: grid;
   gap: 1rem;
-  margin-top: 2rem;
 }
 
 .recipe-item {
@@ -10,6 +54,9 @@
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: box-shadow 0.2s ease;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .recipe-item:hover {

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -1,23 +1,70 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Link, useParams, useNavigate } from 'react-router-dom';
 import { Recipe } from '../../types/Recipe';
 import { allRecipes } from '../../data/allRecipes';
+import Category from '../Category';
 import './RecipeList.css';
 
 /**
  * Component that displays a list of all available recipes
- * Each recipe name is a clickable link to the recipe detail page
  */
 const RecipeList: React.FC = () => {
   const recipes: Recipe[] = allRecipes;
+  const { category: urlCategory } = useParams<{ category: string }>();
+  const navigate = useNavigate();
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  // Get unique categories from all recipes
+  const categories = Array.from(new Set(recipes.map(recipe => recipe.category)));
+
+  // Sync URL category with state
+  useEffect(() => {
+    setSelectedCategory(urlCategory || null);
+  }, [urlCategory]);
+
+  // Toggle category selection and update URL
+  const toggleCategory = (category: string) => {
+    if (selectedCategory === category) {
+      // Deselect - go back to home
+      navigate('/');
+    } else {
+      // Select - navigate to category URL
+      navigate(`/category/${category}`);
+    }
+  };
+
+  // Filter recipes based on selected category
+  const filteredRecipes = selectedCategory 
+    ? recipes.filter(recipe => recipe.category === selectedCategory)
+    : recipes;
 
   return (
-    <div className="recipe-list">
-      {recipes.map((recipe) => (
-        <div key={recipe.id} className="recipe-item">
-          <Link to={`/recipe/${recipe.id}`}>{recipe.name}</Link>
+    <div className="recipe-list-container">
+      <div className="categories-section">
+        <h2>Categories</h2>
+        <div className="categories-list">
+          {categories.map((category) => (
+            <button
+              key={category}
+              className={`category-filter ${selectedCategory === category ? 'active' : ''}`}
+              onClick={() => toggleCategory(category)}
+            >
+              <Category category={category} />
+            </button>
+          ))}
         </div>
-      ))}
+      </div>
+
+      <div className="recipe-list">
+        {filteredRecipes.map((recipe) => (
+          <div key={recipe.id} className="recipe-item">
+            <Link to={`/category/${recipe.category}/recipe/${recipe.id}`} className="recipe-link">
+              {recipe.name}
+            </Link>
+            <Category category={recipe.category} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { Recipe } from '../../types/Recipe';
 import { allRecipes } from '../../data/allRecipes';
-import Category from '../Category';
+import Category from '../Category/Category';
 import './RecipeList.css';
 
 /**

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -6,7 +6,9 @@ import Category from '../Category';
 import './RecipeList.css';
 
 /**
- * Component that displays a list of all available recipes
+ * Displays a list of all available recipes with category filtering capabilities.
+ * Allows users to filter recipes by category, updates the URL to reflect the selected category,
+ * and synchronizes the selected category with the URL for direct navigation and bookmarking.
  */
 const RecipeList: React.FC = () => {
   const recipes: Recipe[] = allRecipes;

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -49,7 +49,7 @@ const RecipeList: React.FC = () => {
               className={`category-filter ${selectedCategory === category ? 'active' : ''}`}
               onClick={() => toggleCategory(category)}
             >
-              <Category category={category} />
+              <Category name={category} />
             </button>
           ))}
         </div>
@@ -61,7 +61,7 @@ const RecipeList: React.FC = () => {
             <Link to={`/category/${recipe.category}/recipe/${recipe.id}`} className="recipe-link">
               {recipe.name}
             </Link>
-            <Category category={recipe.category} />
+            <Category name={recipe.category} />
           </div>
         ))}
       </div>

--- a/src/data/allRecipes.ts
+++ b/src/data/allRecipes.ts
@@ -1,6 +1,7 @@
 import { Recipe } from '../types/Recipe';
 import { spaghettiCarbonara } from './recipes/spaghettiCarbonara';
 import { chickenTikkaMasala } from './recipes/chickenTikkaMasala';
+import { liquoriceCheesecake } from './recipes/liquoriceCheesecake';
 
 /**
  * Complete list of all recipes.
@@ -9,5 +10,6 @@ import { chickenTikkaMasala } from './recipes/chickenTikkaMasala';
  */
 export const allRecipes: Recipe[] = [
   spaghettiCarbonara,
-  chickenTikkaMasala
+  chickenTikkaMasala,
+  liquoriceCheesecake
 ];

--- a/src/data/recipes/chickenTikkaMasala.ts
+++ b/src/data/recipes/chickenTikkaMasala.ts
@@ -3,6 +3,7 @@ import { Recipe } from '../../types/Recipe';
 export const chickenTikkaMasala: Recipe = {
   id: "chicken-tikka-masala",
   name: "Chicken Tikka Masala",
+  category: "dinner",
   ingredients: [
     { name: "chicken breast", amount: "1", unit: "lb" },
     { name: "plain yogurt", amount: "1/2", unit: "cup" },

--- a/src/data/recipes/liquoriceCheesecake.ts
+++ b/src/data/recipes/liquoriceCheesecake.ts
@@ -1,0 +1,34 @@
+import { Recipe } from '../../types/Recipe';
+
+export const liquoriceCheesecake: Recipe = {
+  id: "liquorice-cheesecake",
+  name: "Liquorice Cheesecake",
+  category: "dessert",
+  ingredients: [
+    { name: "digestive biscuits", amount: "200", unit: "g" },
+    { name: "unsalted butter", amount: "80", unit: "g" },
+    { name: "cream cheese", amount: "600", unit: "g" },
+    { name: "caster sugar", amount: "150", unit: "g" },
+    { name: "large eggs", amount: "3", unit: "whole" },
+    { name: "double cream", amount: "300", unit: "ml" },
+    { name: "black liquorice", amount: "100", unit: "g" },
+    { name: "vanilla extract", amount: "1", unit: "tsp" },
+    { name: "plain flour", amount: "2", unit: "tbsp" },
+    { name: "liquorice powder", amount: "2", unit: "tsp" },
+    { name: "salt", amount: "1/4", unit: "tsp" }
+  ],
+  steps: [
+    "Preheat oven to 160°C (140°C fan). Grease and line a 23cm springform cake tin.",
+    "Crush digestive biscuits into fine crumbs and mix with melted butter. Press firmly into the base of the prepared tin.",
+    "Chop black liquorice into small pieces and melt with 2 tbsp of cream in a small saucepan over low heat, stirring until smooth. Set aside to cool.",
+    "Beat cream cheese until smooth, then gradually add sugar, beating until light and fluffy.",
+    "Beat in eggs one at a time, then add vanilla extract and the cooled liquorice mixture.",
+    "Sift together flour, liquorice powder, and salt, then fold into the cream cheese mixture.",
+    "Gradually fold in the remaining cream until just combined. Don't overmix.",
+    "Pour mixture over the biscuit base and smooth the top.",
+    "Bake for 50-60 minutes until the center is just set with a slight wobble.",
+    "Turn off oven and leave cheesecake inside with door ajar for 1 hour to cool gradually.",
+    "Refrigerate for at least 4 hours or overnight before serving.",
+    "Remove from tin and dust with extra liquorice powder if desired before serving."
+  ]
+};

--- a/src/data/recipes/spaghettiCarbonara.ts
+++ b/src/data/recipes/spaghettiCarbonara.ts
@@ -3,6 +3,7 @@ import { Recipe } from '../../types/Recipe';
 export const spaghettiCarbonara: Recipe = {
   id: "spaghetti-carbonara",
   name: "Spaghetti Carbonara",
+  category: "dinner",
   ingredients: [
     { name: "spaghetti", amount: "400", unit: "g" },
     { name: "pancetta", amount: "150", unit: "g" },

--- a/src/types/Recipe.ts
+++ b/src/types/Recipe.ts
@@ -18,6 +18,8 @@ export interface Recipe {
   id: string;
   /** Display name of the recipe */
   name: string;
+  /** Recipe category (e.g., "dinner", "dessert", "breakfast") */
+  category: string;
   /** List of ingredients needed for the recipe */
   ingredients: Ingredient[];
   /** Step-by-step cooking instructions */


### PR DESCRIPTION
Core feature: Adding category of recipes, intended to be dessert, dinner and what-not. Similar to tags, but not really. Probably I will introduce that later on, right now not important.

As part of this, I have added the filter on the list view of the categories, so it only shows e.g. dinner items. I made that selection part of the URL - this gave me the option to add the category as part of the breadcrumb structure and allow quick navigation back the list view with filters already enabled.

also added an extra recipe, a dessert, to see how it works with multiple categories.

Default view:
<img width="1057" height="572" alt="image" src="https://github.com/user-attachments/assets/30d11a13-31a7-43a9-b1c4-900b22ed530d" />
 
With filter:
<img width="928" height="316" alt="image" src="https://github.com/user-attachments/assets/4de2b463-75c5-44f8-8794-db658a885443" />

Show case of breamcrumbs:
<img width="983" height="362" alt="image" src="https://github.com/user-attachments/assets/f93c7f00-4c76-4138-a738-e8214db58dfe" />


