### PR TITLE
feat: Add prep timer for recipies

### DIFF
--- a/src/components/RecipeDetail/RecipeDetail.css
+++ b/src/components/RecipeDetail/RecipeDetail.css
@@ -25,6 +25,28 @@
   margin: 1rem 0;
 }
 
+/* Prep time display */
+.prep-time {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0 2rem 0;
+  padding: 0.75rem 1rem;
+  background: #f8f9fa;
+  border-radius: 6px;
+  border-left: 4px solid #d2691e;
+}
+
+.prep-time-icon {
+  font-size: 1.2rem;
+}
+
+.prep-time-text {
+  font-size: 1rem;
+  color: #555;
+  font-weight: 500;
+}
+
 /* Ingredients section */
 .ingredients-section {
   margin-top: 2rem;

--- a/src/components/RecipeDetail/RecipeDetail.tsx
+++ b/src/components/RecipeDetail/RecipeDetail.tsx
@@ -31,6 +31,13 @@ const RecipeDetail: React.FC = () => {
       />
       <h1 className="recipe-title">{recipe.name}</h1>
       
+      {recipe.prepTime && (
+        <div className="prep-time">
+          <span className="prep-time-icon">⏱️</span>
+          <span className="prep-time-text">Prep time: {recipe.prepTime.amount} {recipe.prepTime.unit}</span>
+        </div>
+      )}
+      
       <section className="ingredients-section">
         <h2>Ingredients</h2>
         <ul className="ingredients-list">

--- a/src/components/RecipeList/RecipeList.css
+++ b/src/components/RecipeList/RecipeList.css
@@ -63,6 +63,12 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
 }
 
+.recipe-main-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .recipe-item a {
   text-decoration: none;
   color: #2c2c2c;
@@ -72,4 +78,20 @@
 
 .recipe-item a:hover {
   color: #d2691e;
+}
+
+.recipe-prep-time {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.recipe-prep-time .prep-time-icon {
+  font-size: 1rem;
+}
+
+.recipe-prep-time .prep-time-text {
+  font-weight: 500;
 }

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -60,9 +60,17 @@ const RecipeList: React.FC = () => {
       <div className="recipe-list">
         {filteredRecipes.map((recipe) => (
           <div key={recipe.id} className="recipe-item">
-            <Link to={`/category/${recipe.category}/recipe/${recipe.id}`} className="recipe-link">
-              {recipe.name}
-            </Link>
+            <div className="recipe-main-info">
+              <Link to={`/category/${recipe.category}/recipe/${recipe.id}`} className="recipe-link">
+                {recipe.name}
+              </Link>
+              {recipe.prepTime && (
+                <div className="recipe-prep-time">
+                  <span className="prep-time-icon">⏱️</span>
+                  <span className="prep-time-text">{recipe.prepTime.amount} {recipe.prepTime.unit}</span>
+                </div>
+              )}
+            </div>
             <Category name={recipe.category} />
           </div>
         ))}

--- a/src/data/recipes/chickenTikkaMasala.ts
+++ b/src/data/recipes/chickenTikkaMasala.ts
@@ -4,6 +4,7 @@ export const chickenTikkaMasala: Recipe = {
   id: "chicken-tikka-masala",
   name: "Chicken Tikka Masala",
   category: "dinner",
+  prepTime: { amount: 45, unit: "minutes" },
   ingredients: [
     { name: "chicken breast", amount: "1", unit: "lb" },
     { name: "plain yogurt", amount: "1/2", unit: "cup" },

--- a/src/data/recipes/liquoriceCheesecake.ts
+++ b/src/data/recipes/liquoriceCheesecake.ts
@@ -4,6 +4,7 @@ export const liquoriceCheesecake: Recipe = {
   id: "liquorice-cheesecake",
   name: "Liquorice Cheesecake",
   category: "dessert",
+  prepTime: { amount: 30, unit: "minutes" },
   ingredients: [
     { name: "digestive biscuits", amount: "200", unit: "g" },
     { name: "unsalted butter", amount: "80", unit: "g" },

--- a/src/data/recipes/spaghettiCarbonara.ts
+++ b/src/data/recipes/spaghettiCarbonara.ts
@@ -4,6 +4,7 @@ export const spaghettiCarbonara: Recipe = {
   id: "spaghetti-carbonara",
   name: "Spaghetti Carbonara",
   category: "dinner",
+  prepTime: { amount: 15, unit: "minutes" },
   ingredients: [
     { name: "spaghetti", amount: "400", unit: "g" },
     { name: "pancetta", amount: "150", unit: "g" },

--- a/src/types/Recipe.ts
+++ b/src/types/Recipe.ts
@@ -11,6 +11,16 @@ export interface Ingredient {
 }
 
 /**
+ * Represents preparation time with flexible amount and unit
+ */
+export interface PrepTime {
+  /** The amount of time (e.g., 15, 30, 45) */
+  amount: number;
+  /** The unit of time (e.g., "minutes", "hours", "days") */
+  unit: string;
+}
+
+/**
  * A single recipe, with everything included.
  */
 export interface Recipe {
@@ -24,4 +34,6 @@ export interface Recipe {
   ingredients: Ingredient[];
   /** Step-by-step cooking instructions */
   steps: string[];
+  /** Preparation time with amount and unit (optional) */
+  prepTime?: PrepTime;
 }


### PR DESCRIPTION
Adding prep timer for recipies, consisting of an amount (number) and unit (e.g. hours). Rendered in the UI: 

<img width="1039" height="567" alt="image" src="https://github.com/user-attachments/assets/6c42c150-55a8-4e63-a9cc-b0b18081cf10" />
<img width="985" height="354" alt="image" src="https://github.com/user-attachments/assets/deedd034-70e6-4ad7-a734-2fb8965fe022" />
