### PR TITLE
refactor: remove category URL navigation as it was annoying

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,7 @@ const App: React.FC = () => {
         <main className="App-content">
           <Routes>
             <Route path="/" element={<RecipeList />} />
-            <Route path="/category/:category" element={<RecipeList />} />
-            <Route path="/category/:category/recipe/:id" element={<RecipeDetail />} />
+            <Route path="/recipe/:id" element={<RecipeDetail />} />
           </Routes>
         </main>
       </div>

--- a/src/components/RecipeDetail/RecipeDetail.tsx
+++ b/src/components/RecipeDetail/RecipeDetail.tsx
@@ -19,7 +19,6 @@ const RecipeDetail: React.FC = () => {
     <div className="recipe-detail">
       <Breadcrumb 
         currentPageLabel={recipe.name} 
-        additionalBreadcrumbItems={[{ label: recipe.category, path: `/category/${recipe.category}` }]}
       />
       <h1 className="recipe-title">{recipe.name}</h1>
       

--- a/src/components/RecipeList/RecipeList.tsx
+++ b/src/components/RecipeList/RecipeList.tsx
@@ -35,7 +35,7 @@ const RecipeList: React.FC = () => {
         {filteredRecipes.map((recipe) => (
           <Link
             key={recipe.id}
-            to={`/category/${recipe.category}/recipe/${recipe.id}`}
+            to={`/recipe/${recipe.id}`}
             className="recipe-item-link"
           >
             <div className="recipe-item">

--- a/src/hooks/useRecipeFiltering.ts
+++ b/src/hooks/useRecipeFiltering.ts
@@ -1,32 +1,24 @@
-import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
 import { Recipe } from '../types/Recipe';
 
 /**
  * Custom hook for recipe filtering and category management
- * Handles URL synchronization, category selection, and recipe filtering
+ * Handles category selection and recipe filtering (no URL routing)
  */
 export const useRecipeFiltering = (recipes: Recipe[]) => {
-  const { category: urlCategory } = useParams<{ category: string }>();
-  const navigate = useNavigate();
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
   // Get unique categories from all recipes
   const categories = Array.from(new Set(recipes.map(recipe => recipe.category)));
 
-  // Sync URL category with state
-  useEffect(() => {
-    setSelectedCategory(urlCategory || null);
-  }, [urlCategory]);
-
-  // Toggle category selection and update URL
+  // Toggle category selection
   const toggleCategory = (category: string) => {
     if (selectedCategory === category) {
-      // Deselect - go back to home
-      navigate('/');
+      // Deselect category
+      setSelectedCategory(null);
     } else {
-      // Select - navigate to category URL
-      navigate(`/category/${category}`);
+      // Select category
+      setSelectedCategory(category);
     }
   };
 


### PR DESCRIPTION
Removed category from URL navigation, because it was annoying.

Going from
`https://andreasmoerch.github.io/recipes/#/category/dinner/recipe/spaghetti-carbonara` to `https://andreasmoerch.github.io/recipes/#/recipe/spaghetti-carbonara`.

The reason for this is actually two-fold. If I wanna introduce tags or similar feature in the future, it will have to partially store the filtering in session storage. Now it can all be stored there. Could be added as query params if needed.


The only UI change this affects is the breadcrumbs:

<img width="1047" height="618" alt="image" src="https://github.com/user-attachments/assets/1766ffeb-b0b7-4149-baac-7c5b22efbf02" />
